### PR TITLE
Allow missing members without throwing exceptions

### DIFF
--- a/Modules.JsonNetFormatter/JsonNetFormatter.cs
+++ b/Modules.JsonNetFormatter/JsonNetFormatter.cs
@@ -31,8 +31,8 @@ namespace Modules.JsonNet
                 },
                 PreserveReferencesHandling = PreserveReferencesHandling.All,
                 TypeNameHandling = TypeNameHandling.All,
-                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
-                
+                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+                MissingMemberHandling = MissingMemberHandling.Ignore
             };
             _serializer = JsonSerializer.Create(settings);
         }


### PR DESCRIPTION
BinaryFormatter does not always throw exceptions when a class member does not exist from the serialized data, but Newtonsoft.Json does.  This allows using JSON files that are versioned independently of their Class objects.  This may be better implemented as a configurable option, rather than explicitly always set to "Ignore" or "Error", but since there were no other configurable options, I didn't want to define that interface.